### PR TITLE
Fix RemovedInDjango40Warning

### DIFF
--- a/debug_toolbar_line_profiler/signals.py
+++ b/debug_toolbar_line_profiler/signals.py
@@ -1,4 +1,4 @@
 import django.dispatch
 
 
-profiler_setup = django.dispatch.Signal(providing_args=['profiler', 'view_func', 'view_args', 'view_kwargs'])
+profiler_setup = django.dispatch.Signal()


### PR DESCRIPTION
RemovedInDjango40Warning: The providing_args argument is deprecated. As it is purely documentational, it has no replacement. If you rely on this argument as documentation, you can move the text to a code comment or docstring.