### PR TITLE
Allow install with django 2.2+

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     license='BSD',
     packages=find_packages(exclude=('tests', 'example')),
     install_requires=[
-        'django>=3.0'
+        'django>=2.2'
         'django-debug-toolbar>=2.0',
         'line_profiler>=1.0b3',
         'six>=1.10',


### PR DESCRIPTION
This seems to work fine with django 2.2–given the strict version enforcement of pip's new resolver I had to fork it to get it to install in a project running django 2.x without jumping through some hoops, so I figured I'd make a PR. Understandable if you don't want to officially support older versions, though 2.2 is LTS for another year or so. Thanks for forking and keeping up to date! This is a super useful tool.